### PR TITLE
docs: update Docker image reference to ghcr.io/stoneyjackson/github-data:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker run --rm \
   -e GITHUB_TOKEN=your_token_here \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=save \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 ```
 
 ### Restore Data
@@ -70,7 +70,7 @@ docker run --rm \
   -e GITHUB_TOKEN=your_token_here \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=restore \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 ```
 
 ### Environment Variables
@@ -104,7 +104,7 @@ docker run --rm \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=restore \
   -e LABEL_CONFLICT_STRATEGY=overwrite \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 ```
 
 #### GitHub Token Permissions
@@ -164,7 +164,7 @@ docker run --rm \
   -e GITHUB_TOKEN=your_token \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=save \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 
 # Backup excluding Git repository (metadata only)
 docker run --rm \
@@ -173,7 +173,7 @@ docker run --rm \
   -e GITHUB_TOKEN=your_token \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=save \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 
 # Backup with bundle format
 docker run --rm \
@@ -182,7 +182,7 @@ docker run --rm \
   -e GITHUB_TOKEN=your_token \
   -e GITHUB_REPO=owner/repository \
   -e OPERATION=save \
-  github-data
+  ghcr.io/stoneyjackson/github-data:latest
 ```
 
 #### Backup Formats


### PR DESCRIPTION
## Summary
• Update all Docker command examples in README.md to use `ghcr.io/stoneyjackson/github-data:latest` instead of the generic `github-data` image name
• Ensures users reference the correct container registry path for the published image

## Test plan
- [x] Verify all Docker commands in README.md use the correct image reference
- [x] Confirm documentation formatting remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)