### PR TITLE
fix: implement client-side position calculation for sub-issues

### DIFF
--- a/src/github/queries/sub_issues.py
+++ b/src/github/queries/sub_issues.py
@@ -28,7 +28,6 @@ REPOSITORY_SUB_ISSUES_QUERY = gql(
                         nodes {
                             id
                             number
-                            position
                         }
                         pageInfo {
                             hasNextPage
@@ -68,7 +67,6 @@ ISSUE_SUB_ISSUES_QUERY = gql(
                     nodes {
                         id
                         number
-                        position
                         title
                         state
                         url

--- a/src/github/utils/data_enrichment.py
+++ b/src/github/utils/data_enrichment.py
@@ -95,10 +95,10 @@ class SubIssueRelationshipBuilder:
         all_sub_issues = []
         for issue in issues_nodes:
             sub_issues = issue.get("subIssues", {}).get("nodes", [])
-            for sub_issue in sub_issues:
+            for position, sub_issue in enumerate(sub_issues, 1):
                 all_sub_issues.append(
                     SubIssueRelationshipBuilder.create_relationship_object(
-                        sub_issue, issue, include_metadata=False
+                        sub_issue, issue, position, include_metadata=False
                     )
                 )
         return all_sub_issues
@@ -119,15 +119,16 @@ class SubIssueRelationshipBuilder:
         """
         return [
             SubIssueRelationshipBuilder.create_relationship_object(
-                sub_issue, parent_issue, include_metadata=True
+                sub_issue, parent_issue, position + 1, include_metadata=True
             )
-            for sub_issue in sub_issues_nodes
+            for position, sub_issue in enumerate(sub_issues_nodes)
         ]
 
     @staticmethod
     def create_relationship_object(
         sub_issue: Dict[str, Any],
         parent_issue: Dict[str, Any],
+        position: int,
         include_metadata: bool = False,
     ) -> Dict[str, Any]:
         """
@@ -136,6 +137,7 @@ class SubIssueRelationshipBuilder:
         Args:
             sub_issue (Dict[str, Any]): Sub-issue details
             parent_issue (Dict[str, Any]): Parent issue details
+            position (int): Position of sub-issue in parent's list
             include_metadata: Include additional metadata. Defaults to False.
 
         Returns:
@@ -146,7 +148,7 @@ class SubIssueRelationshipBuilder:
             "sub_issue_number": sub_issue["number"],
             "parent_issue_id": parent_issue["id"],
             "parent_issue_number": parent_issue["number"],
-            "position": sub_issue.get("position"),
+            "position": position,
         }
 
         if include_metadata:

--- a/tests/unit/test_data_enrichment_unit.py
+++ b/tests/unit/test_data_enrichment_unit.py
@@ -250,7 +250,7 @@ class TestSubIssueRelationshipBuilder:
         }
 
         result = SubIssueRelationshipBuilder.create_relationship_object(
-            sub_issue, parent_issue, include_metadata=False
+            sub_issue, parent_issue, 1, include_metadata=False
         )
 
         expected_keys = {
@@ -283,7 +283,7 @@ class TestSubIssueRelationshipBuilder:
         }
 
         result = SubIssueRelationshipBuilder.create_relationship_object(
-            sub_issue, parent_issue, include_metadata=True
+            sub_issue, parent_issue, 1, include_metadata=True
         )
 
         expected_keys = {
@@ -318,10 +318,10 @@ class TestSubIssueRelationshipBuilder:
         }
 
         result = SubIssueRelationshipBuilder.create_relationship_object(
-            sub_issue, parent_issue, include_metadata=False
+            sub_issue, parent_issue, 1, include_metadata=False
         )
 
-        assert result["position"] is None
+        assert result["position"] == 1
 
 
 class TestURLEnricher:


### PR DESCRIPTION
## Summary

This PR implements client-side position calculation for sub-issues to ensure consistent ordering independent of GitHub's internal position values.

### Changes Made

- **GraphQL Queries**: Removed `position` field from `REPOSITORY_SUB_ISSUES_QUERY` and `ISSUE_SUB_ISSUES_QUERY` in `src/github/queries/sub_issues.py`
- **Data Enrichment**: Updated `SubIssueRelationshipBuilder` in `src/github/utils/data_enrichment.py` to calculate positions using `enumerate()` 
- **API Updates**: Modified `create_relationship_object()` method to accept position as a parameter
- **Tests**: Updated unit tests in `tests/unit/test_data_enrichment_unit.py` to reflect new position calculation approach

### Technical Details

Previously, the code relied on GitHub's internal `position` field which could be inconsistent or unavailable. Now positions are calculated client-side based on the order of sub-issues returned by the API, ensuring deterministic and consistent ordering.

### Test Plan

- [x] Unit tests updated and passing for new position calculation logic
- [x] Position values are now based on array index (1-based) rather than GitHub's internal values
- [x] All existing functionality preserved while improving reliability

🤖 Generated with [Claude Code](https://claude.ai/code)