### PR TITLE
fix: correct GraphQL field name from parentIssue to parent

### DIFF
--- a/src/github/queries/sub_issues.py
+++ b/src/github/queries/sub_issues.py
@@ -34,7 +34,7 @@ REPOSITORY_SUB_ISSUES_QUERY = gql(
                             endCursor
                         }
                     }
-                    parentIssue {
+                    parent {
                         id
                         number
                     }
@@ -76,7 +76,7 @@ ISSUE_SUB_ISSUES_QUERY = gql(
                         endCursor
                     }
                 }
-                parentIssue {
+                parent {
                     id
                     number
                 }


### PR DESCRIPTION
## Summary
- Fixed GraphQL field name from `parentIssue` to `parent` in sub-issues queries
- Resolves save operation failures caused by incorrect GraphQL field reference

## Test plan
- [ ] Verify save operations no longer fail with GraphQL field errors
- [ ] Test sub-issue backup and restore functionality

🤖 Generated with [Claude Code](https://claude.ai/code)