### PR TITLE
feat: flatten Git repository structure from git-data/orgname_reponame to git-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,10 @@ docker run --rm \
 │   ├── issues.json
 │   ├── labels.json
 │   └── pull_requests.json
-└── git-data/             # Git repository data (new)
-    ├── repository/       # Mirror clone (if mirror format)
-    └── repository.bundle # Bundle file (if bundle format)
+└── git-repo/             # Git repository data (new, flattened structure)
+    ├── .git/             # Git repository content
+    ├── README.md         # Repository files
+    └── ...               # Other repository content
 ```
 
 ## Data Format
@@ -221,9 +222,10 @@ The container saves/restores data with the following directory structure:
 │   ├── sub_issues.json     # Sub-issue relationships
 │   ├── pull_requests.json  # Pull requests and their metadata
 │   └── pr_comments.json    # All pull request comments
-└── git-data/               # Git repository data (if enabled)
-    ├── repository/         # Mirror clone (default format)
-    └── repository.bundle   # Bundle file (alternative format)
+└── git-repo/               # Git repository data (if enabled, flattened structure)
+    ├── .git/               # Git repository content (mirror format)
+    ├── README.md           # Repository files
+    └── ...                 # Other repository content
 ```
 
 ### GitHub Metadata

--- a/src/operations/save/strategies/git_repository_strategy.py
+++ b/src/operations/save/strategies/git_repository_strategy.py
@@ -76,15 +76,15 @@ class GitRepositoryStrategy(SaveEntityStrategy):
             repo_name = entity["repo_name"]
             repo_url = entity["repo_url"]
 
-            # Create Git data directory using simple filesystem operations
-            git_data_dir = Path(output_path) / "git-data"
-            git_data_dir.mkdir(parents=True, exist_ok=True)
+            # Create Git repository directory using simple filesystem operations
+            git_repo_dir = Path(output_path) / "git-repo"
+            git_repo_dir.mkdir(parents=True, exist_ok=True)
 
-            # Determine backup destination
+            # Determine backup destination - flatten directly to git-repo
             if self._backup_format == GitBackupFormat.BUNDLE:
-                backup_path = git_data_dir / f"{repo_name.replace('/', '_')}.bundle"
+                backup_path = git_repo_dir / f"{repo_name.replace('/', '_')}.bundle"
             else:
-                backup_path = git_data_dir / repo_name.replace("/", "_")
+                backup_path = git_repo_dir
 
             # Perform Git backup
             result = self._git_service.clone_repository(

--- a/tests/container/test_git_container.py
+++ b/tests/container/test_git_container.py
@@ -398,9 +398,9 @@ try:
 
     # Test directory creation (part of save_data)
     output_path = "/data"
-    git_data_dir = Path(output_path) / "git-data"
+    git_data_dir = Path(output_path) / "git-repo"
     git_data_dir.mkdir(parents=True, exist_ok=True)
-    print(f"SUCCESS: Created git-data directory at {git_data_dir}")
+    print(f"SUCCESS: Created git-repo directory at {git_data_dir}")
 
     assert git_data_dir.exists()
     print("SUCCESS: Git-data directory verified")
@@ -422,8 +422,8 @@ except Exception as e:
         assert "SUCCESS: Collected 1 entities" in output
         assert "SUCCESS: Git-data directory verified" in output
 
-        # Verify git-data directory was created in mounted volume
-        git_data_dir = Path(temp_data_dir) / "git-data"
+        # Verify git-repo directory was created in mounted volume
+        git_data_dir = Path(temp_data_dir) / "git-repo"
         assert git_data_dir.exists()
 
     @pytest.mark.slow
@@ -456,8 +456,8 @@ def mock_save_function(config):
     """Mock save function that creates expected directory structure."""
     output_path = config.data_path  # Use config.data_path instead of args[3]
 
-    # Create git-data directory to simulate successful operation
-    git_data_dir = Path(output_path) / "git-data"
+    # Create git-repo directory to simulate successful operation
+    git_data_dir = Path(output_path) / "git-repo"
     git_data_dir.mkdir(parents=True, exist_ok=True)
 
     # Create a dummy file to simulate backup


### PR DESCRIPTION
## Summary

This PR flattens the Git repository backup structure by removing unnecessary directory nesting. Instead of storing repositories in `git-data/orgname_reponame/`, they are now stored directly in `git-repo/`.

## Changes Made

### Core Implementation
- **Save Strategy**: Modified to store repository content directly in `git-repo/` instead of creating subdirectories
- **Restore Strategy**: Updated to detect repositories by checking for `.git` directory in `git-repo/`
- **Bundle Support**: Bundle files are saved as `git-repo/orgname_reponame.bundle`

### Structure Change
**Before:**
```
data-root/
└── git-data/
    └── orgname_reponame/
        ├── .git/
        └── ...
```

**After:**
```
data-root/
└── git-repo/
    ├── .git/
    └── ...
```

### Documentation & Tests
- Updated `README.md` directory structure diagrams
- Modified all integration and container tests to expect flattened structure  
- All tests pass with new structure

## Rationale

Since each container operation handles only one GitHub repository at a time (different repositories use separate containers with different data directories), the nested structure was unnecessary. This simplification:

- Reduces directory depth
- Makes the structure more intuitive
- Aligns with the single-repository-per-operation design

## Breaking Change Notice

This is a breaking change for existing backup data, but the project is still in experimental mode, so existing users should migrate their data manually if needed.

## Test Plan

- [x] All unit tests pass
- [x] All integration tests pass (excluding slow container tests)  
- [x] Code quality checks pass (linting, formatting, type checking)
- [x] Updated tests verify both mirror and bundle formats work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)