### PR TITLE
feat: add Claude Code configuration with permission settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make test:*)",
+      "Bash(make:*)",
+      "Bash(pdm run pytest:*)",
+      "Bash(pdm run flake8:*)",
+      "Bash(pdm run:*)",
+      "Bash(python -m pytest tests/test_sub_issues_integration.py -v)",
+      "Bash(time make:*)",
+      "Bash(python -m pytest tests/test_metadata.py -v)",
+      "Bash(python -m pytest tests/test_metadata.py::TestMetadataIntegration::test_restore_creates_issues_and_comments_successfully -v)",
+      "Bash(sed:*)",
+      "Bash(tree:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(python:*)",
+      "Bash(find:*)",
+      "Bash(chmod:*)",
+      "Bash(pytest:*)",
+      "Bash(git add:*)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(gh pr:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ Thumbs.db
 # Claude Code
 .claude/*
 !.claude/settings.json
+!.claude/agents/

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ manual-test-repos.local.yml
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Claude Code
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with predefined allowed commands for development workflow
- Update `.gitignore` to exclude `.claude/*` but include `settings.json` for team sharing  
- Enable streamlined Claude Code interactions for testing, building, and git operations

## Test plan

- [x] Verify `.claude/settings.json` is tracked in git
- [x] Confirm other `.claude/*` files are ignored
- [x] Test Claude Code permission system with allowed commands

🤖 Generated with [Claude Code](https://claude.ai/code)